### PR TITLE
fix test and ci pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,30 +50,34 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     needs: [lint, component-tests]
-    # Runs tests in parallel with matrix strategy https://docs.cypress.io/guides/guides/parallelization
-    # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
-    # Also see warning here https://github.com/cypress-io/github-action#parallel
-    strategy:
-      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
-      matrix:
-        containers: [1, 2] # Uses 2 parallel instances
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Build app
+        run: npm run build
+
       - name: Cypress run
         # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
         uses: cypress-io/github-action@v7
         with:
-          install-command: npm install --legacy-peer-deps
-          # Starts web server for E2E tests - replace with your own server invocation
-          # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server
+          install: false
           browser: chrome
-          start: npm run dev
+          start: npm run start
           wait-on: "http://localhost:3000" # Waits for above
+          wait-on-timeout: 120
           # Records to Cypress Cloud
           # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
           record: true
-          parallel: true # Runs test in parallel using settings above
         env:
           # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
           # in GitHub repo → Settings → Secrets → Actions

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -89,17 +89,19 @@ describe("Navigation", () => {
       cy.get(mobileNavElement).should("not.exist");
 
       cy.get(hamburgerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(hamburgerElement).should("have.attr", "aria-expanded", "true");
       cy.get(mobileNavElement).should("be.visible");
       cy.get(mobileNavElement).should("have.attr", "aria-hidden", "false");
 
       cy.get(hamburgerElement).click();
       cy.get(hamburgerElement).should("have.attr", "aria-expanded", "false");
-      cy.get(mobileNavElement).should("not.be.visible");
+      cy.get(mobileNavElement).should("not.exist");
     });
 
     it("should navigate to the correct page when clicking a link in the mobile navigation", () => {
       cy.get(hamburgerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(aboutUsLinkElement).click();
 
       cy.get(mobileNavElement).should("not.be.visible");
@@ -108,6 +110,7 @@ describe("Navigation", () => {
 
       cy.visit("/");
       cy.get(hamburgerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(blogLinkElement).click();
 
       cy.get(mobileNavElement).should("not.be.visible");
@@ -117,6 +120,7 @@ describe("Navigation", () => {
 
     it("should toggle accordion state in mobile navigation and correctly update data-state and aria-expanded attributes", () => {
       cy.get(hamburgerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
 
       cy.get(accordionItemElement).should("be.visible");
       cy.get(accordionItemElement).should("have.attr", "data-state", "closed");
@@ -133,6 +137,7 @@ describe("Navigation", () => {
       );
 
       cy.get(accordionTriggerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(accordionItemElement).should("have.attr", "data-state", "open");
       cy.get(accordionTriggerElement).should("have.attr", "data-state", "open");
       cy.get(accordionTriggerElement).should(
@@ -160,6 +165,7 @@ describe("Navigation", () => {
       const laserTherapyLink = `${accordionItemElement} a:contains('Laseroterapia')`;
 
       cy.get(hamburgerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(accordionTriggerElement).click();
 
       cy.get(holisticTreatmentsLink).should("be.visible");
@@ -171,6 +177,7 @@ describe("Navigation", () => {
 
       cy.visit("/");
       cy.get(hamburgerElement).click();
+      cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(accordionTriggerElement).click();
 
       cy.get(laserTherapyLink).should("be.visible");


### PR DESCRIPTION
- Fixed e2e tests: changed assertions from not.be.visible to not.exist for the mobile nav drawer, since it's unmounted (not just hidden) when closed
- Cleaned up CI/CD pipeline:
  - Removed redundant parallel run (matrix strategy no longer needed with only one test suite)
  - E2E tests now run against a production build instead of the development server