### PR TITLE
Add gallery support to post content

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -11,6 +11,7 @@ describe("Navigation", () => {
     beforeEach(() => {
       cy.viewport("macbook-11");
       cy.visit("/");
+      cy.waitForHydration();
     });
 
     it("should correctly display desktop navigation and allow to navigate to correct page when a link is clicked", () => {
@@ -61,6 +62,7 @@ describe("Navigation", () => {
       );
 
       cy.visit("/");
+      cy.waitForHydration();
       cy.get(dropDownTrigger).click();
       cy.get(bodyShapingDropdownLink).should("be.visible");
       cy.get(bodyShapingDropdownLink).click();
@@ -81,6 +83,7 @@ describe("Navigation", () => {
     beforeEach(() => {
       cy.viewport("iphone-xr");
       cy.visit("/");
+      cy.waitForHydration();
     });
 
     it("should display mobile navigation, allow clicking the hamburger to toggle the mobile navigation, and update ARIA attributes correctly on small screens", () => {
@@ -109,6 +112,7 @@ describe("Navigation", () => {
       cy.contains("h1", "O Nas").should("be.visible");
 
       cy.visit("/");
+      cy.waitForHydration();
       cy.get(hamburgerElement).click();
       cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
       cy.get(blogLinkElement).click();
@@ -166,7 +170,7 @@ describe("Navigation", () => {
 
       cy.get(hamburgerElement).click();
       cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
-      cy.get(accordionTriggerElement).click();
+      cy.clickAccordionTrigger(accordionTriggerElement);
 
       cy.get(holisticTreatmentsLink).should("be.visible");
       cy.get(holisticTreatmentsLink).click();
@@ -176,9 +180,10 @@ describe("Navigation", () => {
       cy.contains("h1", "Holistyczne zabiegi na twarz").should("be.visible");
 
       cy.visit("/");
+      cy.waitForHydration();
       cy.get(hamburgerElement).click();
       cy.get(mobileNavElement).should("have.class", "sideNav-enter-done");
-      cy.get(accordionTriggerElement).click();
+      cy.clickAccordionTrigger(accordionTriggerElement);
 
       cy.get(laserTherapyLink).should("be.visible");
       cy.get(laserTherapyLink).click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -25,13 +25,23 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 //
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+Cypress.Commands.add("waitForHydration", () => {
+  cy.get('html[data-hydrated="true"]', { timeout: 10000 }).should("exist");
+});
+
+Cypress.Commands.add("clickAccordionTrigger", (selector: string) => {
+  cy.get(selector).click();
+  cy.wait(300);
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      waitForHydration(): Chainable<JQuery<HTMLElement>>;
+      clickAccordionTrigger(selector: string): Chainable<void>;
+    }
+  }
+}
+
+export {};

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,3 +1,5 @@
+import "./commands";
+
 Cypress.on("uncaught:exception", (err, _runnable) => {
   console.error("Uncaught exception in this spec:", err);
   console.error("Stack trace:", err.stack);

--- a/src/app/blog/[category]/[slug]/page.tsx
+++ b/src/app/blog/[category]/[slug]/page.tsx
@@ -6,7 +6,30 @@ import Post from "@/components/BlogPage/Category/PostPage/Post/Post";
 import { urlFor } from "@/utils/clientSideUtils";
 import { getImage } from "@/utils/serverSideUtils";
 
-const POST_QUERY = `*[_type == "post" && slug.current == $slug]{altForMainImage, publishedAt, mainImage, title, summary, postContent, category->{title, categorySlug}, treatment->{treatmentSlug, treatmentGroup->{groupSlug}}, treatmentGroup->{groupSlug}}[0]`;
+const POST_QUERY = `*[_type == "post" && slug.current == $slug]{
+  altForMainImage,
+  publishedAt,
+  mainImage,
+  title,
+  summary,
+  postContent[]{
+    ...,
+    _type == "blockContentImage" => {
+      ...,
+      asset->{ _id, url, metadata { dimensions, lqip } }
+    },
+    _type == "gallery" => {
+      ...,
+      images[]{
+        ...,
+        asset->{ _id, url, metadata { dimensions, lqip } }
+      }
+    }
+  },
+  category->{title, categorySlug},
+  treatment->{treatmentSlug, treatmentGroup->{groupSlug}},
+  treatmentGroup->{groupSlug}
+}[0]`;
 
 const options = { next: { revalidate: 30 } };
 
@@ -23,7 +46,6 @@ export default async function PostPage({
 
   const { title: postTitle, category, mainImage } = postData;
   const { title: categoryTitle } = category;
-  // const publishAt = new Date(post.publishedAt).toLocaleDateString();
   const mainImageUrl = urlFor(mainImage)!.fit("max").url();
   const imageData = await getImage(mainImageUrl);
   const postDetails = { ...postData, imageData };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,9 @@ const montserrat = Montserrat({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+  ),
   title: "Klinika Zdrowej Skóry",
   description:
     "Klinika Zdrowej Skóry to wyjątkowe miejsce stworzone z pasji do piękna.",

--- a/src/components/BlogPage/Category/PostPage/GalleryLightBox/GalleryLightBox.tsx
+++ b/src/components/BlogPage/Category/PostPage/GalleryLightBox/GalleryLightBox.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { Dispatch, SetStateAction } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  type CarouselApi,
+} from "@/components/ui/carousel";
+import { GalleryImage } from "@/types/types";
+import { X } from "lucide-react";
+import Image from "next/image";
+
+interface GalleryLightBoxProps {
+  setApi: Dispatch<SetStateAction<CarouselApi | undefined>>;
+  activeIndex: number;
+  images: GalleryImage[];
+  onClose: () => void;
+}
+
+export default function GalleryLightBox({
+  setApi,
+  activeIndex,
+  images,
+  onClose,
+}: GalleryLightBoxProps) {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 p-4"
+      onClick={onClose}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-4 right-4 z-10 text-white"
+        aria-label="Zamknij"
+      >
+        <X size={32} className="cursor-pointer" />
+      </button>
+
+      <div
+        className="mx-auto max-w-[90vw] sm:w-full sm:max-w-md md:max-w-xl lg:max-w-4xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Carousel
+          setApi={setApi}
+          opts={{ align: "start", startIndex: activeIndex ?? 0, loop: true }}
+          className="w-full"
+        >
+          <CarouselContent>
+            {images.map((img) => (
+              <CarouselItem
+                key={img._key}
+                className="basis-full md:basis-1/2 lg:basis-1/3"
+              >
+                <div className="p-1">
+                  <Card>
+                    <CardContent className="relative flex aspect-square items-center justify-center p-6">
+                      <Image
+                        src={img.asset.url}
+                        alt={img.alt || ""}
+                        fill
+                        className="object-contain"
+                        sizes="(max-width: 640px) 90vw, (max-width: 1024px) 45vw, 30vw"
+                        priority
+                      />
+                    </CardContent>
+                  </Card>
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious className="hidden cursor-pointer lg:flex" />
+          <CarouselNext className="hidden cursor-pointer lg:flex" />
+        </Carousel>
+      </div>
+    </div>
+  );
+}

--- a/src/components/BlogPage/Category/PostPage/PortableTextGallery/PortableTextGallery.tsx
+++ b/src/components/BlogPage/Category/PostPage/PortableTextGallery/PortableTextGallery.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import Image from "next/image";
+import { type CarouselApi } from "@/components/ui/carousel";
+
+import GalleryLightBox from "@/components/BlogPage/Category/PostPage/GalleryLightBox/GalleryLightBox";
+import { GalleryImage } from "@/types/types";
+
+interface PortableTextGalleryProps {
+  value: { images: GalleryImage[] };
+}
+
+export default function PortableTextGallery({
+  value,
+}: PortableTextGalleryProps) {
+  const { images } = value;
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [api, setApi] = useState<CarouselApi>();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const close = useCallback(() => setActiveIndex(null), []);
+
+  useEffect(() => {
+    if (api && activeIndex !== null) {
+      api.scrollTo(activeIndex);
+    }
+  }, [api, activeIndex]);
+
+  useEffect(() => {
+    if (activeIndex === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [activeIndex, close]);
+
+  const lightbox = activeIndex !== null && (
+    <GalleryLightBox
+      setApi={setApi}
+      activeIndex={activeIndex}
+      images={images}
+      onClose={close}
+    />
+  );
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3 py-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {images.map((img, i) => (
+          <button
+            key={img._key}
+            type="button"
+            onClick={() => setActiveIndex(i)}
+            className="relative aspect-square overflow-hidden rounded-[var(--big-border-radius)]"
+          >
+            <Image
+              src={img.asset.url}
+              alt={img.alt || ""}
+              fill
+              placeholder={img.asset.metadata?.lqip ? "blur" : "empty"}
+              blurDataURL={img.asset.metadata?.lqip}
+              className="cursor-pointer object-cover transition-transform duration-300 hover:scale-105"
+              sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 33vw"
+            />
+          </button>
+        ))}
+      </div>
+
+      {mounted && lightbox && createPortal(lightbox, document.body)}
+    </>
+  );
+}

--- a/src/components/Layout/Navigation/Navigation.tsx
+++ b/src/components/Layout/Navigation/Navigation.tsx
@@ -46,6 +46,10 @@ export default function Navigation({ navData }: NavigationProps) {
     }
   }, [scrollDirection, isTop, headerClasses]);
 
+  useEffect(() => {
+    document.documentElement.setAttribute("data-hydrated", "true");
+  }, []);
+
   const clickHandler = () => {
     setAttachedClasses([headerClasses.toolbar, headerClasses.toolbarBoxShadow]);
   };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -99,3 +99,12 @@ export interface ErrorState {
   errorMessage: string;
   hasError: boolean;
 }
+
+export interface GalleryImage {
+  _key: string;
+  alt?: string;
+  asset: {
+    url: string;
+    metadata: { dimensions: { width: number; height: number }; lqip?: string };
+  };
+}

--- a/src/utils/portableTextComponentConfig.tsx
+++ b/src/utils/portableTextComponentConfig.tsx
@@ -2,6 +2,7 @@ import { PortableTextComponents } from "next-sanity";
 import Image from "next/image";
 
 import { urlFor } from "@/utils/clientSideUtils";
+import PortableTextGallery from "@/components/BlogPage/Category/PostPage/PortableTextGallery/PortableTextGallery";
 
 export const portableTextComponentConfig: PortableTextComponents = {
   marks: {
@@ -10,12 +11,17 @@ export const portableTextComponentConfig: PortableTextComponents = {
     ),
   },
   types: {
-    image: ({ value }) => {
-      const width = value.asset?.metadata?.dimensions?.width;
-      const height = value.asset?.metadata?.dimensions?.height;
+    blockContentImage: ({ value }) => {
+      const { height, width } = value.asset?.metadata?.dimensions ?? {};
+      const sizeClass =
+        value.size === "small"
+          ? "w-1/2 mx-auto"
+          : value.size === "medium"
+            ? "w-3/4 mx-auto"
+            : "w-full";
 
       return (
-        <div className="relative py-3">
+        <div className={`relative py-3 ${sizeClass}`}>
           <Image
             src={urlFor(value.asset)?.fit("max").url() || ""}
             alt={value.alt}
@@ -26,6 +32,7 @@ export const portableTextComponentConfig: PortableTextComponents = {
         </div>
       );
     },
+    gallery: PortableTextGallery,
   },
   block: {
     normal: ({ children }) => <p className="mb-[16px]">{children}</p>,


### PR DESCRIPTION
- Updated POST_QUERY to resolve blockContentImage and gallery asset references (image metadata, dimensions, lqip) via GROQ projections instead of relying on default dereferencing
- Renamed the inline image type to blockContentImage and added size variants (small / medium / full-width) via a new sizeClass mapping
- Added GalleryImage type to types.ts
- Added two new components: GalleryLightBox and PortableTextGallery
- Registered PortableTextGallery in portableTextComponentConfig for the gallery block type
- Fixed a console warning by adding metadataBase to layout.tsx's metadata export